### PR TITLE
Add GitHub Actions for CI and release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: build
+
+on:
+  push:
+    branches:
+    - '*'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        os: [ ubuntu-20.04 ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Make all
+        run: make all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    strategy:
+      matrix:
+        go-version: [ 1.15.x ]
+        os: [ ubuntu-20.04 ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Make all
+        run: make all
+      - name: Upload release binaries
+        uses: alexellis/upload-assets@0.2.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["./_output/nerdctl"]'


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

Adds a build for Go and a release upload as per the arkade and k3sup project.

Feel free to take this as an initial commit for a Linux binary, and then add other cross-compilation options when you have time.

Tested on my fork: 

* CI build - https://github.com/alexellis/nerdctl/actions/runs/410243071
* Release build and artifact - https://github.com/alexellis/nerdctl/actions/runs/410245763 - https://github.com/alexellis/nerdctl/releases/tag/0.0.1

<img width="1202" alt="Screenshot 2020-12-09 at 09 23 11" src="https://user-images.githubusercontent.com/6358735/101610482-38114900-3a00-11eb-9f45-6a4325c8ce71.png">
