### PR TITLE
add `nerdctl logs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Container management:
   - `--no-trunc`: Don't truncate output
   - `-q, --quiet`: Only display container IDs
 
+- `nerdctl logs`
+
 - `nerdctl rm`
   - `-f`
 

--- a/cio.go
+++ b/cio.go
@@ -1,0 +1,81 @@
+/*
+   Copyright (C) nerdctl authors.
+   Copyright (C) containerd authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"io"
+	"net/url"
+	"os"
+
+	"github.com/containerd/console"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+	"github.com/pkg/errors"
+)
+
+// newTask is from https://github.com/containerd/containerd/blob/v1.4.3/cmd/ctr/commands/tasks/tasks_unix.go#L70-L108
+func newTask(ctx context.Context, client *containerd.Client, container containerd.Container, flagI, flagT, flagD bool, con console.Console, logURI string) (containerd.Task, error) {
+	stdinC := &stdinCloser{
+		stdin: os.Stdin,
+	}
+	var ioCreator cio.Creator
+	if flagT {
+		if con == nil {
+			return nil, errors.New("got nil con with flagT=true")
+		}
+		ioCreator = cio.NewCreator(cio.WithStreams(con, con, nil), cio.WithTerminal)
+	} else if flagD && logURI != "" {
+		// TODO: support logURI for `nerdctl run -it`
+		u, err := url.Parse(logURI)
+		if err != nil {
+			return nil, err
+		}
+		ioCreator = cio.LogURI(u)
+	} else {
+		var in io.Reader
+		if flagI {
+			in = stdinC
+		}
+		ioCreator = cio.NewCreator(cio.WithStreams(in, os.Stdout, os.Stderr))
+	}
+	t, err := container.NewTask(ctx, ioCreator)
+	if err != nil {
+		return nil, err
+	}
+	stdinC.closer = func() {
+		t.CloseIO(ctx, containerd.WithStdinCloser)
+	}
+	return t, nil
+}
+
+// stdinCloser is from https://github.com/containerd/containerd/blob/v1.4.3/cmd/ctr/commands/tasks/exec.go#L181-L194
+type stdinCloser struct {
+	stdin  *os.File
+	closer func()
+}
+
+func (s *stdinCloser) Read(p []byte) (int, error) {
+	n, err := s.stdin.Read(p)
+	if err == io.EOF {
+		if s.closer != nil {
+			s.closer()
+		}
+	}
+	return n, err
+}

--- a/internal_logging.go
+++ b/internal_logging.go
@@ -1,0 +1,114 @@
+/*
+   Copyright (C) nerdctl authors.
+   Copyright (C) containerd authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/runtime/v2/logging"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const internalLoggingArgKey = "_NERDCTL_INTERNAL_LOGGING_ARG"
+
+func internalLoggingMain(arg string) error {
+	fn, err := getLoggerFunc(arg)
+	if err != nil {
+		return err
+	}
+	logging.Run(fn)
+	return nil
+}
+
+func getLoggerFunc(dataRoot string) (logging.LoggerFunc, error) {
+	if dataRoot == "" {
+		return nil, errors.New("got empty data-root")
+	}
+	return func(_ context.Context, config *logging.Config, ready func() error) error {
+		if config.Namespace == "" || config.ID == "" {
+			return errors.New("got invalid config")
+		}
+		logJSONFilePath := getLogJSONPath(dataRoot, config.Namespace, config.ID)
+		if err := os.MkdirAll(filepath.Dir(logJSONFilePath), 0700); err != nil {
+			return err
+		}
+		logJSONFile, err := os.OpenFile(logJSONFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			return err
+		}
+		defer logJSONFile.Close()
+		if err := ready(); err != nil {
+			return err
+		}
+		return writeLogJSON(logJSONFile, config.Stdout, config.Stderr)
+	}, nil
+}
+
+func getLogJSONPath(dataRoot, ns, id string) string {
+	// the file name corresponds to Docker
+	return filepath.Join(dataRoot, "c", ns, id, id+"-json.log")
+}
+
+func writeLogJSON(w io.Writer, stdout, stderr io.Reader) error {
+	enc := json.NewEncoder(w)
+	var encMu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(2)
+	f := func(r io.Reader, name string) {
+		defer wg.Done()
+		br := bufio.NewReader(r)
+		e := &LogJSONEntry{
+			Stream: name,
+		}
+		for {
+			line, err := br.ReadString(byte('\n'))
+			if err != nil {
+				logrus.WithError(err).Errorf("faild to read line from %q", name)
+				return
+			}
+			e.Log = line
+			e.Time = time.Now().UTC()
+			encMu.Lock()
+			encErr := enc.Encode(e)
+			encMu.Unlock()
+			if encErr != nil {
+				logrus.WithError(err).Errorf("faild to encode JSON")
+				return
+			}
+		}
+	}
+	go f(stdout, "stdout")
+	go f(stderr, "stderr")
+	wg.Wait()
+	return nil
+}
+
+// LogJSONEntry is compatible with Docker, but not efficient
+type LogJSONEntry struct {
+	Log    string    `json:"log"` // line, including "\r\n"
+	Stream string    `json:"stream"`
+	Time   time.Time `json:"time"` // e.g. "2020-12-11T20:29:41.939902251Z"
+}

--- a/logs.go
+++ b/logs.go
@@ -1,0 +1,99 @@
+/*
+   Copyright (C) nerdctl authors.
+   Copyright (C) containerd authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/AkihiroSuda/nerdctl/pkg/idutil"
+	"github.com/containerd/containerd"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+var logsCommand = &cli.Command{
+	Name:      "logs",
+	Usage:     "Fetch the logs of a container. Currently, only containers created with `nerdctl logs -d` are supported.",
+	ArgsUsage: "[flags] CONTAINER",
+	Action:    logsAction,
+}
+
+func logsAction(clicontext *cli.Context) error {
+	if clicontext.NArg() != 1 {
+		return errors.Errorf("requires exactly 1 argument")
+	}
+	argIDs := clicontext.Args().Slice()
+
+	dataRoot := clicontext.String("data-root")
+
+	ns := clicontext.String("namespace")
+	switch ns {
+	case "moby", "k8s.io":
+		logrus.Warn("Currently, `nerdctl logs` only supports containers created with `nerdctl logs -d`")
+	}
+
+	client, ctx, cancel, err := newClient(clicontext)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	var exactID string
+	if err := idutil.WalkContainers(ctx, client, argIDs,
+		func(ctx context.Context, _ *containerd.Client, shortID, id string) error {
+			if exactID != "" {
+				return errors.Errorf("ambiguous ID %q", shortID)
+			}
+			exactID = id
+			return nil
+		}); err != nil {
+		return err
+	}
+	logJSONFilePath := getLogJSONPath(dataRoot, ns, exactID)
+	f, err := os.Open(logJSONFilePath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open %q, container is not created with `nerdctl logs -d`?", logJSONFilePath)
+	}
+	defer f.Close()
+	return decodeLogJSON(clicontext.App.Writer, clicontext.App.ErrWriter, f)
+}
+
+func decodeLogJSON(stdout, stderr io.Writer, logJSONReader io.Reader) error {
+	dec := json.NewDecoder(logJSONReader)
+	for {
+		var e LogJSONEntry
+		if err := dec.Decode(&e); err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		switch e.Stream {
+		case "stdout":
+			stdout.Write([]byte(e.Log))
+		case "stderr":
+			stderr.Write([]byte(e.Log))
+		default:
+			logrus.Errorf("unknown stream name %q, entry=%+v", e.Stream, e)
+		}
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -32,9 +32,19 @@ import (
 )
 
 func main() {
-	if err := newApp().Run(os.Args); err != nil {
+	if err := xmain(); err != nil {
 		logrus.Fatal(err)
 	}
+}
+
+func xmain() error {
+	if len(os.Args) == 3 && os.Args[1] == internalLoggingArgKey {
+		// containerd runtime v2 logging plugin mode.
+		// "binary://BIN?KEY=VALUE" URI is parsed into Args {BIN, KEY, VALUE}.
+		return internalLoggingMain(os.Args[2])
+	}
+	// nerdctl CLI mode
+	return newApp().Run(os.Args)
 }
 
 func newApp() *cli.App {
@@ -105,6 +115,7 @@ func newApp() *cli.App {
 		runCommand,
 		// Container management
 		psCommand,
+		logsCommand,
 		stopCommand,
 		rmCommand,
 		pauseCommand,


### PR DESCRIPTION
FIXME: log is enabled only for `-d` containers. And yet no support for `--restart=always`.

---

Close #15