### PR TITLE
Fix auth error on pulling private image with "not well-knwon" port

### DIFF
--- a/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
+++ b/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
@@ -18,6 +18,7 @@
 package dockerconfigresolver
 
 import (
+	"net"
 	"net/url"
 
 	"github.com/containerd/containerd/remotes"
@@ -78,7 +79,11 @@ func New(refHostname string) (remotes.Resolver, error) {
 					if err != nil {
 						return nil, errors.Wrapf(err, "failed to parse ac.ServerAddress %q", ac.ServerAddress)
 					}
-					if acsaHostname := acsaURL.Hostname(); acsaHostname != authConfigHostname {
+					acsaHostname := acsaURL.Hostname()
+					if acsaPort := acsaURL.Port(); acsaPort != "" {
+						acsaHostname = net.JoinHostPort(acsaHostname, acsaPort)
+					}
+					if acsaHostname != authConfigHostname {
 						return nil, errors.Errorf("expected the hostname part of ac.ServerAddress (%q) to be authConfigHostname=%q, got %q",
 							ac.ServerAddress, authConfigHostname, acsaHostname)
 					}


### PR DESCRIPTION
Currently, private images with "not well-known" port (e.g. `registry2:5000`) cannot be pulled with nerdctl.
This commit fixes this.

```console
# nerdctl pull registry2:5000/alpine:3.10.2
FATA[0000] expected the hostname part of ac.ServerAddress ("https://registry2:5000") to be authConfigHostname="registry2:5000", got "registry2" 
```
