### PR TITLE
support `--insecure-registry`

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ Show the nerdctl version information
 - :nerd_face: `--cni-netconfpath`: CNI netconf path (default: `/etc/cni/net.d`) [`$NETCONFPATH`]
 - :nerd_face: `--data-root`: nerdctl data root, e.g. "/var/lib/nerdctl"
 - :nerd_face: `--cgroup-manager=(cgroupfs|systemd)`: cgroup manager
+- :nerd_face: `--insecure-registry`: skips verifying HTTPS certs, and allows falling back to plain HTTP
 
 ## Unimplemented Docker commands
 Container management:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,8 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |v|
     v.memory = memory
     v.cpus = cpus
+    # The default CIDR conflicts with slirp4netns CIDR (10.0.2.0/24)
+    v.customize ["modifyvm", :id, "--natnet1", "192.168.42.0/24"]
   end
   config.vm.provider :libvirt do |v|
     v.memory = memory

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -3,3 +3,19 @@
 nerdctl uses `${DOCKER_CONFIG}/config.json` for the authentication with image registries.
 
 `$DOCKER_CONFIG` defaults to `$HOME/.docker`.
+
+## Using insecure registry
+
+If you face `http: server gave HTTP response to HTTPS client` and you cannot configure TLS for the registry, try `--insecure-registry` flag:
+
+e.g.,
+```console
+$ nerdctl --insecure-registry run --rm 192.168.12.34:5000/foo
+```
+
+## Accessing 127.0.0.1 from rootless nerdctl
+
+Currently, rootless nerdctl cannot pull images from 127.0.0.1, because
+the pull operation occurs in RootlessKit's network namespace.
+
+See https://github.com/AkihiroSuda/nerdctl/issues/86 for the discussion about workarounds.

--- a/main.go
+++ b/main.go
@@ -110,6 +110,10 @@ func newApp() *cli.App {
 			Usage: "Cgroup manager to use (\"cgroupfs\"|\"systemd\")",
 			Value: ncdefaults.CgroupManager(),
 		},
+		&cli.BoolFlag{
+			Name:  "insecure-registry",
+			Usage: "skips verifying HTTPS certs, and allows falling back to plain HTTP",
+		},
 	}
 	app.Before = func(clicontext *cli.Context) error {
 		if debug {

--- a/pkg/imgutil/pull/pull.go
+++ b/pkg/imgutil/pull/pull.go
@@ -73,6 +73,7 @@ func Pull(ctx context.Context, client *containerd.Client, ref string, config *Co
 	}
 	opts = append(opts, config.RemoteOpts...)
 
+	// client.Pull is for single-platform (TODO: support multi)
 	img, err := client.Pull(pctx, ref, opts...)
 	stopProgress()
 	if err != nil {

--- a/pkg/imgutil/push/push.go
+++ b/pkg/imgutil/push/push.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/progress"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -39,7 +40,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func Push(ctx context.Context, client *containerd.Client, resolver remotes.Resolver, stdout io.Writer, localRef, remoteRef string) error {
+func Push(ctx context.Context, client *containerd.Client, resolver remotes.Resolver, stdout io.Writer,
+	localRef, remoteRef string, platform platforms.MatchComparer) error {
 	img, err := client.ImageService().Get(ctx, localRef)
 	if err != nil {
 		return errors.Wrap(err, "unable to resolve image to manifest")
@@ -66,6 +68,7 @@ func Push(ctx context.Context, client *containerd.Client, resolver remotes.Resol
 		return client.Push(ctx, remoteRef, desc,
 			containerd.WithResolver(resolver),
 			containerd.WithImageHandler(jobHandler),
+			containerd.WithPlatformMatcher(platform),
 		)
 	})
 

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -214,4 +214,5 @@ const (
 	AlpineImage                 = "mirror.gcr.io/library/alpine:3.13"
 	NginxAlpineImage            = "mirror.gcr.io/library/nginx:1.19-alpine"
 	NginxAlpineIndexHTMLSnippet = "<title>Welcome to nginx!</title>"
+	RegistryImage               = "mirror.gcr.io/library/registry:2"
 )

--- a/pull.go
+++ b/pull.go
@@ -40,6 +40,8 @@ func pullAction(clicontext *cli.Context) error {
 		return err
 	}
 	defer cancel()
-	_, err = imgutil.EnsureImage(ctx, client, clicontext.App.Writer, clicontext.String("snapshotter"), clicontext.Args().First(), "always")
+	insecure := clicontext.Bool("insecure-registry")
+	_, err = imgutil.EnsureImage(ctx, client, clicontext.App.Writer, clicontext.String("snapshotter"), clicontext.Args().First(),
+		"always", insecure)
 	return err
 }

--- a/push_test.go
+++ b/push_test.go
@@ -1,0 +1,137 @@
+/*
+   Copyright (C) nerdctl authors.
+   Copyright (C) containerd authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/AkihiroSuda/nerdctl/pkg/testutil"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/pkg/errors"
+	"gotest.tools/v3/assert"
+)
+
+func getNonLoopbackIPv4() (net.IP, error) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, err
+	}
+	for _, addr := range addrs {
+		ip, _, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			continue
+		}
+		ipv4 := ip.To4()
+		if ipv4 == nil {
+			continue
+		}
+		if ipv4.IsLoopback() {
+			continue
+		}
+		return ipv4, nil
+	}
+	return nil, errors.Wrapf(errdefs.ErrNotFound, "non-loopback IPv4 address not found, attempted=%+v", addrs)
+}
+
+type testRegistry struct {
+	ip         net.IP
+	listenIP   net.IP
+	listenPort int
+	cleanup    func()
+}
+
+func newTestRegistry(base *testutil.Base, name string) *testRegistry {
+	hostIP, err := getNonLoopbackIPv4()
+	assert.NilError(base.T, err)
+	// listen on 0.0.0.0 to enable 127.0.0.1
+	listenIP := net.ParseIP("0.0.0.0")
+	const listenPort = 5000 // TODO: choose random empty port
+	base.T.Logf("hostIP=%q, listenIP=%q, listenPort=%d", hostIP, listenIP, listenPort)
+
+	registryContainerName := "reg-" + name
+	cmd := base.Cmd("run",
+		"-d",
+		"-p", fmt.Sprintf("%s:%d:5000", listenIP, listenPort),
+		"--name", registryContainerName,
+		testutil.RegistryImage)
+	cmd.AssertOK()
+	if _, err = httpGet(fmt.Sprintf("http://%s:%d/v2", hostIP.String(), listenPort), 30); err != nil {
+		base.Cmd("rm", "-f", registryContainerName).Run()
+		base.T.Fatal(err)
+	}
+	return &testRegistry{
+		ip:         hostIP,
+		listenIP:   listenIP,
+		listenPort: listenPort,
+		cleanup:    func() { base.Cmd("rm", "-f", registryContainerName).Run() },
+	}
+}
+
+func TestPushPlainHTTPFails(t *testing.T) {
+	base := testutil.NewBase(t)
+	reg := newTestRegistry(base, "test-push-plain-http-fails")
+	defer reg.cleanup()
+
+	base.Cmd("pull", testutil.AlpineImage).AssertOK()
+	testImageRef := fmt.Sprintf("%s:%d/test-push-plain-http-fails:%s",
+		reg.ip.String(), reg.listenPort, strings.Split(testutil.AlpineImage, ":")[1])
+	t.Logf("testImageRef=%q", testImageRef)
+	base.Cmd("tag", testutil.AlpineImage, testImageRef).AssertOK()
+
+	res := base.Cmd("push", testImageRef).Run()
+	resCombined := res.Combined()
+	t.Logf("result: exitCode=%d, out=%q", res.ExitCode, res.Combined())
+	assert.Assert(t, res.ExitCode != 0)
+	assert.Assert(t, strings.Contains(resCombined, "server gave HTTP response to HTTPS client"))
+}
+
+func TestPushPlainHTTPLocalhost(t *testing.T) {
+	base := testutil.NewBase(t)
+	reg := newTestRegistry(base, "test-push-plain-localhost")
+	defer reg.cleanup()
+	localhostIP := "127.0.0.1"
+	t.Logf("localhost IP=%q", localhostIP)
+
+	base.Cmd("pull", testutil.AlpineImage).AssertOK()
+	testImageRef := fmt.Sprintf("%s:%d/test-push-plain-http-insecure:%s",
+		localhostIP, reg.listenPort, strings.Split(testutil.AlpineImage, ":")[1])
+	t.Logf("testImageRef=%q", testImageRef)
+	base.Cmd("tag", testutil.AlpineImage, testImageRef).AssertOK()
+
+	base.Cmd("push", testImageRef).AssertOK()
+}
+
+func TestPushPlainHTTPInsecure(t *testing.T) {
+	// Skip docker, because "dockerd --insecure-registries" requires restarting the daemon
+	testutil.DockerIncompatible(t)
+
+	base := testutil.NewBase(t)
+	reg := newTestRegistry(base, "test-push-plain-http-insecure")
+	defer reg.cleanup()
+
+	base.Cmd("pull", testutil.AlpineImage).AssertOK()
+	testImageRef := fmt.Sprintf("%s:%d/test-push-plain-http-insecure:%s",
+		reg.ip.String(), reg.listenPort, strings.Split(testutil.AlpineImage, ":")[1])
+	t.Logf("testImageRef=%q", testImageRef)
+	base.Cmd("tag", testutil.AlpineImage, testImageRef).AssertOK()
+
+	base.Cmd("--insecure-registry", "push", testImageRef).AssertOK()
+}

--- a/run.go
+++ b/run.go
@@ -235,7 +235,8 @@ func runAction(clicontext *cli.Context) error {
 	imageless := clicontext.Bool("rootfs")
 	var ensured *imgutil.EnsuredImage
 	if !imageless {
-		ensured, err = imgutil.EnsureImage(ctx, client, clicontext.App.Writer, clicontext.String("snapshotter"), clicontext.Args().First(), clicontext.String("pull"))
+		ensured, err = imgutil.EnsureImage(ctx, client, clicontext.App.Writer, clicontext.String("snapshotter"), clicontext.Args().First(),
+			clicontext.String("pull"), clicontext.Bool("insecure-registry"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
e.g., `nerdctl --insecure-registry run -it --rm 192.168.12.34/foo`
